### PR TITLE
fix timezone and SL slot bug

### DIFF
--- a/src/client/public/static/clan/progress.js
+++ b/src/client/public/static/clan/progress.js
@@ -23,7 +23,7 @@ var vm = new Vue({
             axios.post('../api/', {
                 action: 'get_challenge',
                 csrf_token: csrf_token,
-                ts: (thisvue.get_today() / 1000) + 43200,
+                ts: (thisvue.get_now() / 1000),
             }),
             axios.post('../api/', {
                 action: 'get_member_list',
@@ -44,18 +44,15 @@ var vm = new Vue({
                 m.detail = [];
             }
             thisvue.today = res.data.today;
-            thisvue.reportDate = thisvue.get_today();
             thisvue.refresh(res.data.challenges);
         })).catch(function (error) {
             thisvue.$alert(error, '获取数据失败');
         });
     },
     methods: {
-        get_today: function () {
+        get_now: function () {
             let d = new Date();
-            d -= 18000000;
-            d = new Date(d).setHours(0, 0, 0, 0);
-            return d;
+            return Date.parse(d);
         },
         csummary: function (cha) {
             if (cha == undefined) {
@@ -69,9 +66,10 @@ var vm = new Vue({
             }
             var nd = new Date();
             nd.setTime(cha.challenge_time * 1000);
-            var detailstr = nd.toLocaleString('chinese', { hour12: false, timeZone: 'asia/shanghai' }) + '\n';
+            var tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+            var detailstr = nd.toLocaleString('chinese', { hour12: false, timeZone: tz }) + '\n';
             detailstr += cha.cycle + '周目' + cha.boss_num + '号boss\n';
-            detailstr += (cha.health_ramain + cha.damage).toLocaleString(options = { timeZone: 'asia/shanghai' }) + '→' + cha.health_ramain.toLocaleString(options = { timeZone: 'asia/shanghai' });
+            detailstr += (cha.health_ramain + cha.damage).toLocaleString(options = { timeZone: tz }) + '→' + cha.health_ramain.toLocaleString(options = { timeZone: tz });
             if (cha.message) {
                 detailstr += '\n留言：' + cha.message;
             }
@@ -97,7 +95,7 @@ var vm = new Vue({
             axios.post('../api/', {
                 action: 'get_challenge',
                 csrf_token: csrf_token,
-                ts: (thisvue.reportDate ? (thisvue.reportDate.getTime() / 1000) + 43200 : null),
+                ts: (thisvue.reportDate ? (thisvue.reportDate.getTime() - thisvue.reportDate.getTimezoneOffset() * 60000) / 1000  : null),
             }).then(function (res) {
                 if (res.data.code != 0) {
                     thisvue.$alert(res.data.message, '获取记录失败');

--- a/src/client/public/static/clan/progress.js
+++ b/src/client/public/static/clan/progress.js
@@ -16,6 +16,7 @@ var vm = new Vue({
         send_via_private: false,
         dropMemberVisible: false,
         today: 0,
+        isToday: false,
     },
     mounted() {
         var thisvue = this;
@@ -44,6 +45,7 @@ var vm = new Vue({
                 m.detail = [];
             }
             thisvue.today = res.data.today;
+            thisvue.isToday = true;
             thisvue.refresh(res.data.challenges);
         })).catch(function (error) {
             thisvue.$alert(error, '获取数据失败');
@@ -92,20 +94,21 @@ var vm = new Vue({
         },
         report_day: function (event) {
             var thisvue = this;
+            var reportDatetime = (thisvue.reportDate ? (thisvue.reportDate.getTime() - thisvue.reportDate.getTimezoneOffset() * 60000) / 1000  : null);
             axios.post('../api/', {
                 action: 'get_challenge',
                 csrf_token: csrf_token,
-                ts: (thisvue.reportDate ? (thisvue.reportDate.getTime() - thisvue.reportDate.getTimezoneOffset() * 60000) / 1000  : null),
+                ts: reportDatetime,
             }).then(function (res) {
                 if (res.data.code != 0) {
                     thisvue.$alert(res.data.message, '获取记录失败');
                 } else {
                     thisvue.refresh(res.data.challenges);
+                    thisvue.isToday = (thisvue.reportDate ? thisvue.today == Math.floor(reportDatetime / 86400) : true);
                 }
             }).catch(function (error) {
                 thisvue.$alert(error, '获取记录失败');
             })
-            this.today = -1;
         },
         refresh: function (challenges) {
             challenges.sort((a, b) => a.qqid - b.qqid);

--- a/src/client/public/template/clan/progress.html
+++ b/src/client/public/template/clan/progress.html
@@ -136,7 +136,7 @@
         </el-table-column>
         <el-table-column prop="sl" label="SL" width="55" sortable>
           <template slot-scope="scope">
-            <template v-if="today==-1">-</template>
+            <template v-if="!isToday">-</template>
             <template v-else>
               <i class="el-icon-smoking" :style="{color:(scope.row.sl==today?'#F56C6C':'#67C23A')}"></i>
             </template>


### PR DESCRIPTION
修复查刀页面的时区bug，该bug会导致非东八区用户在加载页面时显示异常。

请求api时调用pcr_datetime，该函数传入的是unix时间戳，返回pcr_date和pcr_time
所以在页面加载后发送请求时应该发送当前unix时间戳，在reportDate显示的应该是pcr_date
reportDate的值是浏览器当地时间（带时差），选择日期后发送请求时应该先消除消除时差
