### PR TITLE
多人同时申请出刀的支持，分离“锁定”和“申请出刀”功能

### DIFF
--- a/src/client/ybplugins/clan_battle/battle.py
+++ b/src/client/ybplugins/clan_battle/battle.py
@@ -36,6 +36,7 @@ class ClanBattle:
         '创建': 1,
         '加入': 2,
         '状态': 3,
+        '进度': 27,
         '报刀': 4,
         '尾刀': 5,
         '撤销': 6,
@@ -62,7 +63,8 @@ class ClanBattle:
         '查4': 24,
         '查5': 25,
         '强制': 26,
-        '下树': 28
+        '清空': 28,
+        '下树': 30,
     }
 
     Server = {
@@ -127,7 +129,7 @@ class ClanBattle:
             return 3  # 35~44 周目：四阶段
         return 4  # 45~ 周目：五阶段
 
-    @timed_cached_func(128, 3600, ignore_self=True)
+    @timed_cached_func(65536, 86400, ignore_self=True)
     def _get_nickname_by_qqid(self, qqid) -> Union[str, None]:
         user = User.get_or_create(qqid=qqid)[0]
         if user.nickname is None:
@@ -168,7 +170,7 @@ class ClanBattle:
             group.save()
         return True
 
-    @async_cached_func(16)
+    @async_cached_func(128)
     async def _fetch_member_list_async(self, group_id):
         try:
             group_member_list = await self.api.get_group_member_list(group_id=group_id)
@@ -185,7 +187,9 @@ class ClanBattle:
             user = User.get_or_create(qqid=member['user_id'])[0]
             membership = Clan_member.get_or_create(
                 group_id=group_id, qqid=member['user_id'])[0]
-            user.nickname = member.get('card') or member.get('nickname') or member['user_id']
+            user.nickname = (member.get('card')
+                             or member.get('nickname')
+                             or member['user_id'])
             user.clan_group_id = group_id
             if user.authority_group >= 10:
                 user.authority_group = (
@@ -197,12 +201,22 @@ class ClanBattle:
         # refresh member list
         self.get_member_list(group_id, nocache=True)
 
+    @timed_cached_func(8, 3600, ignore_self=True)
+    async def _get_friends_nickname_dict_async(self):
+        friend_list = await self.api.get_friend_list()
+        friend_dict = {}
+        for f in friend_list:
+            friend_dict[f['user_id']] = f['nickname']
+        return friend_dict
+
     async def _update_user_nickname_async(self, qqid, group_id=None):
         try:
             user = User.get_or_create(qqid=qqid)[0]
             if group_id is None:
-                userinfo = await self.api.get_stranger_info(user_id=qqid)
-                user.nickname = userinfo['nickname']
+                friend_dict = await self._get_friends_nickname_dict_async()
+                user.nickname = friend_dict.get(qqid, 'unknown')
+                # userinfo = await self.api.get_stranger_info(user_id=qqid)
+                # user.nickname = userinfo['nickname']
             else:
                 userinfo = await self.api.get_group_member_info(
                     group_id=group_id, user_id=qqid)
@@ -846,13 +860,11 @@ class ClanBattle:
             message=message,
         )
 
-    def get_subscribe_list(self, group_id: Groupid, boss_num=None) -> List[Tuple[int, QQid, dict]]:
+    def get_subscribe_list(self, group_id: Groupid, boss_num=None, order_by="sid") -> List[Dict[str, Any]]:
         """
         get the subscribe lists.
-
         return a list of subscribe infomation,
         each item is a tuple of (boss_id, qq_id, message)
-
         Args:
             group_id: group id
         """
@@ -863,7 +875,8 @@ class ClanBattle:
         for subscribe in Clan_subscribe.select().where(
                 *query
         ).order_by(
-            Clan_subscribe.sid
+            # Clan_subscribe.sid
+            getattr(Clan_subscribe, order_by)
         ):
             subscribe_list.append({
                 'boss': subscribe.subscribe_item,
@@ -888,10 +901,16 @@ class ClanBattle:
         ).execute()
         return deleted_counts
 
+    def clear_subscribe(self, group_id: Groupid, boss_num) -> int:
+        cleared_counts = Clan_subscribe.delete().where(
+            Clan_subscribe.gid == group_id,
+            Clan_subscribe.subscribe_item == boss_num,
+        ).execute()
+        return cleared_counts
+
     def notify_subscribe(self, group_id: Groupid, boss_num=None, send_private_msg=False):
         """
         send notification to subsciber and remove them (when boss is defeated).
-
         Args:
             group_id: group id
             boss_num: number of new boss
@@ -903,21 +922,33 @@ class ClanBattle:
             boss_num = group.boss_num
         notice = []
         for subscribe in Clan_subscribe.select().where(
-                Clan_subscribe.gid == group_id,
-                (Clan_subscribe.subscribe_item == boss_num) |
-                (Clan_subscribe.subscribe_item == 0),
+            Clan_subscribe.gid == group_id,
+            (Clan_subscribe.subscribe_item == boss_num) |
+            (Clan_subscribe.subscribe_item == 0),
         ).order_by(Clan_subscribe.sid):
             msg = atqq(subscribe.qqid)
             if subscribe.message:
                 msg += subscribe.message
             notice.append(msg)
-            if subscribe.subscribe_item == 0:  # 如果是挂树，则删除
+            # 如果是挂树，则删除
+            if subscribe.subscribe_item == 0:
                 subscribe.delete_instance()
+                continue
+            # 如果预约者选择了“仅提醒一次”，则删除
+            try:
+                notify_user = User.get_by_id(subscribe.qqid)
+            except peewee.DoesNotExist:
+                _logger.warning('预约者用户不存在')
+                continue
+            if notify_user.notify_preference == 1:
+                subscribe.delete_instance()
+                continue
         if notice:
             asyncio.ensure_future(self.api.send_group_msg(
                 group_id=group_id,
-                message='boss已被击败\n' + '\n'.join(notice),
+                message='boss已被击败\n'+'\n'.join(notice),
             ))
+
 
     def apply_for_challenge(self,
                             group_id: Groupid,
@@ -1205,6 +1236,55 @@ class ClanBattle:
             })
         return report
 
+    def get_clan_daily_challenge_counts(self,
+                                        group_id: Groupid,
+                                        pcrdate: Optional[Pcr_date] = None,
+                                        battle_id: Union[int, None] = None,
+                                        ):
+        """
+        get the records
+        Args:
+            group_id: group id
+            battle_id: battle id
+            pcrdate: pcrdate of report
+        """
+        group = Clan_group.get_or_none(group_id=group_id)
+        if group is None:
+            raise GroupNotExist
+        if pcrdate is None:
+            pcrdate = pcr_datetime(group.game_server)[0]
+        if battle_id is None:
+            battle_id = group.battle_id
+        full_challenge_count = 0
+        tailing_challenge_count = 0
+        continued_challenge_count = 0
+        continued_tailing_challenge_count = 0
+        for challenge in Clan_challenge.select().where(
+            Clan_challenge.gid == group_id,
+            Clan_challenge.bid == battle_id,
+            Clan_challenge.challenge_pcrdate == pcrdate,
+        ):
+            if challenge.boss_health_ramain != 0:
+                if challenge.is_continue:
+                    # 剩余刀
+                    continued_challenge_count += 1
+                else:
+                    # 完整刀
+                    full_challenge_count += 1
+            else:
+                if challenge.is_continue:
+                    # 尾余刀
+                    continued_tailing_challenge_count += 1
+                else:
+                    # 尾刀
+                    tailing_challenge_count += 1
+        return (
+            full_challenge_count,
+            tailing_challenge_count,
+            continued_challenge_count,
+            continued_tailing_challenge_count,
+        )
+
     @timed_cached_func(max_len=64, max_age_seconds=10, ignore_self=True)
     def get_battle_member_list(self,
                                group_id: Groupid,
@@ -1350,6 +1430,28 @@ class ClanBattle:
             except ClanBattleError as e:
                 return str(e)
             return boss_summary
+        elif match_num == 27:  # 进度
+            if cmd != '进度':
+                return
+            try:
+                (
+                    full_challenge_count,
+                    tailing_challenge_count,
+                    continued_challenge_count,
+                    continued_tailing_challenge_count,
+                ) = self.get_clan_daily_challenge_counts(group_id)
+            except GroupNotExist as e:
+                return str(e)
+            finished = (full_challenge_count
+                        + continued_challenge_count
+                        + continued_tailing_challenge_count)
+            unfinished = (tailing_challenge_count
+                          - continued_challenge_count
+                          - continued_tailing_challenge_count)
+            return ("今日进度\n\n"
+                    f"已完成出刀：{finished}\n"
+                    f"未完成的尾刀：{unfinished}\n"
+                    f"未开始的出刀：{90-finished-unfinished}")
         elif match_num == 4:  # 报刀
             match = re.match(
                 r'^报刀 ?(\d+)([Ww万Kk千])? *(?:\[CQ:at,qq=(\d+)\])? *(昨[日天])? *(?:[\:：](.*))?$', cmd)
@@ -1383,16 +1485,17 @@ class ClanBattle:
             except ClanBattleError as e:
                 _logger.info('群聊 失败 {} {} {}'.format(user_id, group_id, cmd))
                 return str(e)
-            if behalf:
-                user_id = match.group(3) and int(match.group(3))
-            group = Clan_group.get_or_none(group_id=group_id)
-            boss_num = group.boss_num
-            counts = self.cancel_subscribe(group_id, user_id, boss_num)
+            # if behalf:
+            #     user_id = match.group(3) and int(match.group(3))
+            # group = Clan_group.get_or_none(group_id=group_id)
+            # boss_num = group.boss_num
+            # counts = self.cancel_subscribe(group_id, user_id, boss_num)
             _logger.info('群聊 成功 {} {} {}'.format(user_id, group_id, cmd))
-            if counts != 0:
-                return str(boss_status) + '\n※已取消该boss的预约'
-            else:
-                return str(boss_status)
+            return str(boss_status)
+            # if counts != 0:
+            #     return str(boss_status) + '\n※已取消该boss的预约'
+            # else:
+            #     return str(boss_status)
         elif match_num == 5:  # 尾刀
             match = re.match(
                 r'^尾刀 ?(?:\[CQ:at,qq=(\d+)\])? *(昨[日天])? *(?:[\:：](.*))?$', cmd)
@@ -1463,6 +1566,29 @@ class ClanBattle:
             )
             return '请在面板中查看：' + url
         elif match_num == 10:  # 预约
+            if cmd == '预约表':
+                # 查询预约表
+                subscribers = self.get_subscribe_list(
+                    group_id, order_by='subscribe_item')
+                if not subscribers:
+                    return '没有预约记录'
+                reply = "预约表：\n"
+                current_boss = '-1'  # 尚未开始输出结果
+                for sub in subscribers:
+                    if sub['boss'] != current_boss:  # boss 号变化前，显示小标题
+                        if sub['boss'] == 0:
+                            reply += '====挂树====\n'
+                        else:
+                            reply += f"==={sub['boss']}号boss===\n"
+                        current_boss = sub['boss']
+                    reply += self._get_nickname_by_qqid(sub['qqid'])  # 显示昵称
+                    message = sub['message']  # 如果有留言则显示留言
+                    if message:
+                        reply += '：' + message
+                    reply += '\n'
+                reply += '============'  # 结束
+                return reply
+            # 预约 boss
             match = re.match(r'^预约([1-5]) *(?:[\:：](.*))?$', cmd)
             if not match:
                 return
@@ -1547,7 +1673,7 @@ class ClanBattle:
                 return '您没有' + event
             _logger.info('群聊 成功 {} {} {}'.format(user_id, group_id, cmd))
             return '已取消' + event
-        elif match_num == 28:  # 下树
+        elif match_num == 30:  # 下树
             boss_num = 0
             event = '挂树'
             counts = self.cancel_subscribe(group_id, user_id, boss_num)
@@ -1576,6 +1702,25 @@ class ClanBattle:
                         return '{}没有'.format(atqq(user_id)) + event
                     _logger.info('群聊 成功 {} {} {}'.format(user_id, group_id, cmd))
                     return '已为{}取消'.format(atqq(user_id)) + event
+        elif match_num == 28:  # 清空预约
+            match = re.match(
+                r'^清空(?:预约)?([1-5])? *$', cmd)
+            if match:
+                if ctx['sender']['role'] == 'member':
+                    return '只有管理员才可以清空预约表'
+                elif not match.group(1):
+                    return '请加上需要清空预约的boss'
+                else:
+                    boss_num = match.group(1) and int(match.group(1))
+                    event = f'已清空{boss_num}号boss的预约'
+                    counts = self.clear_subscribe(group_id, boss_num)
+                    if counts == 0:
+                        _logger.info('群聊 失败 {} {}'.format(
+                            group_id, cmd))
+                        return '该boss的预约表为空'
+                    _logger.info('群聊 成功 {} {}'.format(
+                        user_id, cmd))
+                    return event
         elif match_num == 14:  # 解锁
             if cmd != '解锁':
                 return

--- a/src/client/ybplugins/ybdata.py
+++ b/src/client/ybplugins/ybdata.py
@@ -66,7 +66,8 @@ class Clan_group(_BaseModel):
     boss_cycle = SmallIntegerField(default=1)
     boss_num = SmallIntegerField(default=1)
     boss_health = BigIntegerField(default=6000000)
-    challenging_member_qq_id = IntegerField(null=True)
+    challenging_member_qq_id = TextField(null=True) # 改成字符串方便多人，也省的改数据库表格
+    lock_member_qq_id=IntegerField(null=True)# 锁定和申请出刀分开
     boss_lock_type = IntegerField(default=0)  # 1出刀中，2其他
     challenging_start_time = BigIntegerField(default=0)
     challenging_comment = TextField(null=True)


### PR DESCRIPTION
现在可以多人同时申请出刀，方便管理人员查看，但是**因为小改了数据库，可原先的`yobot_data`不兼容**，因此需要使用者清除数据重新配置

- 多人申请出刀时，只用发送`申请出刀`即可，因为要将数据库改动范围要尽量降低，所以看起来存储方式可能很蠢，，。

- 锁定和解锁功能为管理员使用功能，管理员锁定之后不能继续申请出刀，（之前多人申请出刀之后，管理员可以锁定并留言），等待管理员解锁之后或者有人`尾刀`之后便可重新申请出刀。每个申请的人的昵称都可以通过`状态`指令查看，或者在网页内查看，成员`申请出刀`之后也会提醒已经有几人申请，防止撞刀。

- 新增指令`下树`和`取消申请`，`下树`为之前的`取消挂树`命令简化，而`取消申请`则为分离`锁定`和`申请出刀`两个命令设计的，管理员`锁定`指令对应的命令是`解锁`，成员`申请出刀`命令对应的命令是`取消申请`